### PR TITLE
Wlfy10 support fixes 1

### DIFF
--- a/containers/sip-servlets-as10/src/main/java/org/mobicents/io/undertow/server/session/ConvergedInMemorySessionManager.java
+++ b/containers/sip-servlets-as10/src/main/java/org/mobicents/io/undertow/server/session/ConvergedInMemorySessionManager.java
@@ -172,13 +172,11 @@ public class ConvergedInMemorySessionManager implements SessionManager, SessionM
 
     //this method should be called after session is created by sessionManager.createSession()
     //FIXME:kakonyii. sessionManager.createSession() is also called from  io.undertow.util.Sessions.getOrCreateSession(), so this method should be called from there also
-    public void addConvergedSessionDeletegateToSession(SessionConfig sessionCookieConfig, HttpServerExchange serverExchange, ConvergedSessionDelegate convergedSessionDelegate){
-        String sessionId = sessionCookieConfig.findSessionId(serverExchange);
+    public void addConvergedSessionDeletegateToSession(String sessionId, ConvergedSessionDelegate convergedSessionDelegate){
         ConvergedInMemorySession sess = sessions.get(sessionId);
         if(sess!=null){
             sess.addConvergedSessionDelegate(convergedSessionDelegate);
         }
-
     }
 
     @Override

--- a/containers/sip-servlets-as10/src/main/java/org/mobicents/servlet/sip/startup/ConvergedServletContextImpl.java
+++ b/containers/sip-servlets-as10/src/main/java/org/mobicents/servlet/sip/startup/ConvergedServletContextImpl.java
@@ -186,7 +186,7 @@ public final class ConvergedServletContextImpl implements ServletContext {
                 //call access after creation to set LastAccessTime at sipAppSession.
                 httpSession.access();
                 //add delegate to InMemorySession to call sipAppSession.access(), when necessary:
-                ((ConvergedInMemorySessionManager)sessionManager).addConvergedSessionDeletegateToSession(c, exchange, httpSession.getConvergedSessionDelegate());
+                ((ConvergedInMemorySessionManager)sessionManager).addConvergedSessionDeletegateToSession(newSession.getId(), httpSession.getConvergedSessionDelegate());
 
                 exchange.putAttachment(sessionAttachmentKey, httpSession);
             }


### PR DESCRIPTION
This PR consist two bug fixes in connection to the solution for issue #118:
     1. In SIP War deployment process phase the jboss servlet metadata parsed by Undertow is unwillingly overwritten as a sideeffect.
     2. In the new version of Undertow used by WFLY10 the session handling is modified so new session Id is no longer stored in the 
request cookies of the HttpServerExchange only in the response header. This cause a null pointer exception when a http servlet is called.