### PR TITLE
Fix NPE bug in the undeploy method of  UndertowSipDeploymentProcessor #134

### DIFF
--- a/containers/sip-servlets-as10-drop-in/jboss-as-restcomm/src/main/java/org/mobicents/as10/deployment/UndertowSipDeploymentProcessor.java
+++ b/containers/sip-servlets-as10-drop-in/jboss-as-restcomm/src/main/java/org/mobicents/as10/deployment/UndertowSipDeploymentProcessor.java
@@ -175,9 +175,11 @@ public class UndertowSipDeploymentProcessor implements DeploymentUnitProcessor {
 
 	private void removeFromConvergedDeployments(ServiceRegistry serviceRegistry, String deploymentName) {
 		ServiceName containerServiceName = ConvergedServletContainerService.SERVICE_NAME;
-		ConvergedServletContainerService containerService = (ConvergedServletContainerService) serviceRegistry
-				.getService(containerServiceName).getValue();
-		containerService.removeConvergedDeployment(deploymentName);
+		ServiceController<ConvergedServletContainerService> sc = (ServiceController<ConvergedServletContainerService>)serviceRegistry.getService(containerServiceName);
+		if (sc != null) {
+			ConvergedServletContainerService containerService = sc.getValue();
+			containerService.removeConvergedDeployment(deploymentName);
+		}
 	}
 
 	private boolean isSipDeployment(DeploymentUnit deploymentUnit) {


### PR DESCRIPTION
Hi Jean,

When the container stop the ConvergedServletContainerService service could be stopped before UndertowSipDeploymentProcessor.undeploy method is called. A null check should solve this problem.

Best Regards,
Gabor