### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -45,7 +45,7 @@
                 <repository>
                         <id>maven2-repository.dev.java.net</id>
                         <name>Java.net Repository for Maven</name>
-                        <url>http://download.java.net/maven/2/</url>
+                        <url>https://download.java.net/maven/2/</url>
                         <layout>default</layout>
                 </repository>
                 <repository>
@@ -79,7 +79,7 @@
                 <repository>
             <id>backup.repository.jboss.org</id>
             <name>JBoss Repository Backup</name>
-            <url>http://anonsvn.jboss.org/repos/repository.jboss.org/maven2/</url>
+            <url>https://anonsvn.jboss.org/repos/repository.jboss.org/maven2/</url>
                         <snapshots>
                                 <enabled>true</enabled>
                         </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,7 @@
 			<id>java.net-Public</id>
 			<name>Maven Java Net Snapshots and Releases</name>
 			<!--url>https://maven.java.net/content/groups/public/</url -->
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<releases>
 				<enabled>true</enabled>
 				<updatePolicy>never</updatePolicy>
@@ -550,7 +550,7 @@
 		<repository>
 			<id>backup.repository.jboss.org</id>
 			<name>JBoss Repository Backup</name>
-			<url>http://anonsvn.jboss.org/repos/repository.jboss.org/maven2/</url>
+			<url>https://anonsvn.jboss.org/repos/repository.jboss.org/maven2/</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/sip-servlets-arquillian-testsuite/ProxyTest/pom.xml
+++ b/sip-servlets-arquillian-testsuite/ProxyTest/pom.xml
@@ -261,7 +261,7 @@
 		<repository>
 			<id>telscale-releases-repository</id>
 			<name>TelScale Releases Repository</name>
-			<url>http://telestax.artifactoryonline.com/telestax/releases</url>
+			<url>https://telestax.artifactoryonline.com/telestax/releases</url>
 			<releases>
 				<enabled>true</enabled>
 				<updatePolicy>never</updatePolicy>
@@ -274,7 +274,7 @@
 		<repository>
 			<id>telscale-snapshots-repository</id>
 			<name>TelScale Snapshots Repository</name>
-			<url>http://telestax.artifactoryonline.com/telestax/snapshots</url>
+			<url>https://telestax.artifactoryonline.com/telestax/snapshots</url>
 			<releases>
 				<enabled>false</enabled>
 				<updatePolicy>never</updatePolicy>

--- a/sip-servlets-examples/TeleMedicinePh1/pom.xml
+++ b/sip-servlets-examples/TeleMedicinePh1/pom.xml
@@ -40,7 +40,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/alerting-app/pom.xml
+++ b/sip-servlets-examples/alerting-app/pom.xml
@@ -33,7 +33,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/call-blocking/pom.xml
+++ b/sip-servlets-examples/call-blocking/pom.xml
@@ -39,7 +39,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/call-forwarding-distributable/pom.xml
+++ b/sip-servlets-examples/call-forwarding-distributable/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/call-forwarding/pom.xml
+++ b/sip-servlets-examples/call-forwarding/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/chatserver/pom.xml
+++ b/sip-servlets-examples/chatserver/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/click-to-call-servlet3/pom.xml
+++ b/sip-servlets-examples/click-to-call-servlet3/pom.xml
@@ -48,7 +48,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/click-to-call/pom.xml
+++ b/sip-servlets-examples/click-to-call/pom.xml
@@ -36,7 +36,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/click2call-distributable/pom.xml
+++ b/sip-servlets-examples/click2call-distributable/pom.xml
@@ -43,7 +43,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/custom-call-forwarding-distributable/pom.xml
+++ b/sip-servlets-examples/custom-call-forwarding-distributable/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/diameter-openims/pom.xml
+++ b/sip-servlets-examples/diameter-openims/pom.xml
@@ -67,7 +67,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/facebook-c2c/pom.xml
+++ b/sip-servlets-examples/facebook-c2c/pom.xml
@@ -117,7 +117,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/jruby-sips-demo/pom.xml
+++ b/sip-servlets-examples/jruby-sips-demo/pom.xml
@@ -77,7 +77,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/jslee-sips-interop/pom.xml
+++ b/sip-servlets-examples/jslee-sips-interop/pom.xml
@@ -122,7 +122,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/location-service-distributable/pom.xml
+++ b/sip-servlets-examples/location-service-distributable/pom.xml
@@ -46,7 +46,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/location-service/pom.xml
+++ b/sip-servlets-examples/location-service/pom.xml
@@ -36,7 +36,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/media-jsr309-servlet/pom.xml
+++ b/sip-servlets-examples/media-jsr309-servlet/pom.xml
@@ -106,7 +106,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/messaging-perf-test/pom.xml
+++ b/sip-servlets-examples/messaging-perf-test/pom.xml
@@ -34,7 +34,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/pom.xml
+++ b/sip-servlets-examples/pom.xml
@@ -100,7 +100,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/presence-client-example/pom.xml
+++ b/sip-servlets-examples/presence-client-example/pom.xml
@@ -60,7 +60,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/pure-jruby-telco/pom.xml
+++ b/sip-servlets-examples/pure-jruby-telco/pom.xml
@@ -70,7 +70,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/shootist-sip-servlet-distributable/pom.xml
+++ b/sip-servlets-examples/shootist-sip-servlet-distributable/pom.xml
@@ -36,7 +36,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/shootist-sip-servlet/pom.xml
+++ b/sip-servlets-examples/shootist-sip-servlet/pom.xml
@@ -28,7 +28,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/shopping-demo-jsr309/pom.xml
+++ b/sip-servlets-examples/shopping-demo-jsr309/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/simple-sip-servlet/pom.xml
+++ b/sip-servlets-examples/simple-sip-servlet/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/sip-rtsp-gateway/pom.xml
+++ b/sip-servlets-examples/sip-rtsp-gateway/pom.xml
@@ -51,7 +51,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/speed-dial/pom.xml
+++ b/sip-servlets-examples/speed-dial/pom.xml
@@ -37,7 +37,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/uac-register/pom.xml
+++ b/sip-servlets-examples/uac-register/pom.xml
@@ -34,7 +34,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-examples/websocket-b2bua/pom.xml
+++ b/sip-servlets-examples/websocket-b2bua/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>maven2-repository.dev.java.net</id>
 			<name>Java.net Repository for Maven</name>
-			<url>http://download.java.net/maven/2/</url>
+			<url>https://download.java.net/maven/2/</url>
 			<layout>default</layout>
 		</repository>
 		<repository>

--- a/sip-servlets-test-suite/testsuite/pom.xml
+++ b/sip-servlets-test-suite/testsuite/pom.xml
@@ -328,7 +328,7 @@
     <repositories>
         <repository>
             <id>equalsverifier-repository</id>
-            <url>http://equalsverifier.googlecode.com/svn/maven/</url>
+            <url>https://equalsverifier.googlecode.com/svn/maven/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)

- [Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)
- [Update: Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/bugbountywriteup/update-want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-d069d253fe23?source=friends_link&sk=8c8e52a7d57b98d0b7e541665688b454)

---

This is a security fix for a  vulnerability in your [Apache Maven](https://maven.apache.org/) `pom.xml` file(s).

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS.
This leaves your build vulnerable to allowing a [Man in the Middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (MITM) attackers to execute arbitrary code on your or your computer or CI/CD system.

This vulnerability has a CVSS v3.0 Base Score of [8.1/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H).

[POC code](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/) has existed since 2014 to maliciously compromise a JAR file in-flight.
MITM attacks against HTTP are [increasingly common](https://security.stackexchange.com/a/12050), for example [Comcast is known to have done it to their own users](https://thenextweb.com/insights/2017/12/11/comcast-continues-to-inject-its-own-code-into-websites-you-visit/#).

This contribution is a part of a submission to the [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by [LGTM.com](https://lgtm.com) using this [CodeQL Query](https://lgtm.com/rules/1511115648721/).

As of September 2019 LGTM.com and Semmle are [officially a part of GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [LGTM App](https://github.com/marketplace/lgtm).

I'm not an employee of GitHub nor of Semmle, I'm simply a user of [LGTM.com](https://lgtm.com) and an open-source security researcher.

## Source

Yes, this contribution was automatically generated, however, the code to generate this PR was lovingly hand crafted to bring this security fix to your repository.

The source code that generated and submitted this PR can be found here:
[JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/bulk-security-pr-generator
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Tracking

All PR's generated as part of this fix are tracked here: 
https://github.com/JLLeitschuh/bulk-security-pr-generator/issues/2